### PR TITLE
move: Tech Transfer from Engagement to Support Departments

### DIFF
--- a/web/src/app/data/departments/supportUnitsData.json
+++ b/web/src/app/data/departments/supportUnitsData.json
@@ -14,14 +14,6 @@
             "Custom tool development, tailored to specific data formats, project goals, or industrial requirements."
 
         ],
-        "elements": [
-            {
-                "text": "",
-                "content": [
-                    ""
-                ]
-            }
-        ],
         "type": "support" 
     },
     {
@@ -39,14 +31,11 @@
             "Through these services, the center helps transform compliance into an engine for innovation, ensuring AI technologies are developed and deployed safely, ethically, and successfully."
 
         ],
-        "elements": [
-            {
-                "text": "",
-                "content": [
-                    ""
-                ]
-            }
-        ],
+        "type": "support" 
+    },
+    {
+        "name": "Technology Transfer & Development Unit",
+        "description": [],
         "type": "support" 
     }
 ]

--- a/web/src/app/research/departments/DepartmentsClient.js
+++ b/web/src/app/research/departments/DepartmentsClient.js
@@ -9,6 +9,7 @@ import supUnits from "@/app/data/departments/supportUnitsData.json";
 import { allStaff } from "@/app/data/staffData";
 import { proData } from "@/app/data/proData";
 import { pubData } from "@/app/data/pubData";
+import { techTransferPage } from "./TechTransferClient.js";
 
 const researchUnits = Array.isArray(units) ? units : [];
 const supportUnits = Array.isArray(supUnits) ? supUnits : [];
@@ -560,6 +561,9 @@ export default function DepartmentsClient() {
                 {unitView === "details" && (
                   <motion.div variants={containerVariants} initial="hidden" animate="visible">
                     <motion.div variants={itemVariants} className="space-y-4">
+                      {selectedUnit.name==="Technology Transfer & Development Unit" && (
+                        <>{techTransferPage}</>
+                      )}
                       {selectedUnit.description && (
                         <p className="text-gray-700 dark:text-gray-300">{selectedUnit.description}</p>
                       )}

--- a/web/src/app/research/departments/TechTransferClient.js
+++ b/web/src/app/research/departments/TechTransferClient.js
@@ -1,0 +1,59 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1, transition: { delayChildren: 0.2, staggerChildren: 0.12 } },
+};
+const itemVariants = {
+  hidden: { y: 16, opacity: 0 },
+  visible: { y: 0, opacity: 1, transition: { duration: 0.45, ease: "easeOut" } },
+};
+
+export const techTransferPage = Client();
+
+export default function Client() {
+  return (
+    <main>
+      <motion.div
+        className="container max-w-6xl mx-auto bg-white dark:bg-gray-950 rounded-2xl shadow-xl"
+        variants={containerVariants}
+        initial="hidden"
+        animate="visible"
+      >
+        <section>
+          <motion.p
+            className="text-gray-700 dark:text-gray-300 mb-6"
+            variants={itemVariants}
+          >
+            We support technology transfer: IP identification, licensing, prototyping, and spin-offs.
+          </motion.p>
+
+          <motion.div
+            className="mt-2 rounded-2xl border border-gray-200 dark:border-gray-800 overflow-hidden"
+            variants={itemVariants}
+          >
+            <div className="px-4 md:px-6 py-4 border-b border-gray-200 dark:border-gray-800">
+              <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+                Services
+              </h2>
+            </div>
+            <div className="px-4 md:px-6 py-6">
+              <motion.ul
+                className="list-disc pl-6 space-y-1 text-sm text-gray-700 dark:text-gray-300"
+                variants={containerVariants}
+                initial="hidden"
+                animate="visible"
+              >
+                <motion.li variants={itemVariants}>TRL assessment & roadmap</motion.li>
+                <motion.li variants={itemVariants}>Rapid prototyping</motion.li>
+                <motion.li variants={itemVariants}>Industry matchmaking</motion.li>
+              </motion.ul>
+            </div>
+          </motion.div>
+        </section>
+      </motion.div>
+    </main>
+  );
+}


### PR DESCRIPTION
Moved the Client.js page from the engagement/tech-transfer folder to departments folder; renamed the file; exported the page in techTransferPage;

TechTransferClient.js - removed the title and part of the css so the page matches the other support departments

DepartmentsClient.js - imported techTransferPage; checked if selectedUnit.name is Technology Transfer, then techTransferPage is displayed;

supportUnitsData.json - added the Technology Transfer & Development Unit to the file; description is blank; removed the elements from the file